### PR TITLE
Fix background colour setting not applied to most elements

### DIFF
--- a/src/baca/resources/style.css
+++ b/src/baca/resources/style.css
@@ -26,6 +26,14 @@ Screen {
   layers: content search windows;
 }
 
+.-dark-mode Screen {
+  background: $dark-bg;
+}
+
+.-light-mode Screen {
+  background: $light-bg;
+}
+
 LoadingIndicator {
   layer: windows;
 }


### PR DESCRIPTION
Fixes #14.

Based on my testing, the only element that still uses the default colour theme is the keymap table that shows when you press `F1`. Here's how it looks for me when the background colour is set to `#002B36` in `config.ini`:

![table](https://github.com/wustho/baca/assets/10419911/4237ad17-485b-4382-a4c9-81039711da8f)

While I don't consider this a big problem, I thought I would still mention this.

Any suggestions and feedback are welcome!